### PR TITLE
Regexp tweak

### DIFF
--- a/HashSyntax.py
+++ b/HashSyntax.py
@@ -24,6 +24,6 @@ class HashSyntaxCommand(sublime_plugin.TextCommand):
         # Get the selected text
         s = self.view.substr(region)
         # Transform Ruby 1.8 hash syntax to 1.9
-        s = re.sub(r'([^\:])\:([a-zA-Z_0-9]+[\?\!]?)(\s*)=\>(\s*)', new_style_hash, s)
+        s = re.sub(r'([^\:]?)\:([a-zA-Z_0-9]+[\?\!]?)(\s*)=\>(\s*)', new_style_hash, s)
         # Replace the selection with transformed text
         self.view.replace(edit, region, s)


### PR DESCRIPTION
Hi, the hash conversion wasn't working for me on selections where the first character was a colon - something fairly common when the hash is the last argument on a method call:

```ruby
foobar(123, :foo => :bar)
```

If the selection was limited to `:foo => :bar` then no substitution would be made.

I've made the initial `([^\:])` clause optional - is there some case where this could have unwanted consequences? I've been trying on a medium-sized Rails app and the conversion didn't seem to create bad artifacts
 